### PR TITLE
Stabilize

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "doc"]
 	path = doc
-	url = git@github.com:pornel/lodepng-rust.git
+	url = https://github.com/pornel/lodepng-rust.git
 	branch = gh-pages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 
 [dependencies]
 c_vec = "1.0.11"
+libc = "0.1.8"
 
 [[example]]
 name = "read"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ authors = [ "Kornel <pornel@pornel.net>" ]
 build = "build.rs"
 
 [dependencies]
-c_vec = "1.0.11"
 libc = "0.1.8"
+c_vec = "1.0.12"
 
 [[example]]
 name = "read"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![crate_name = "lodepng"]
 #![crate_type = "lib"]
-#![feature(libc)]
-#![feature(unique)]
 
 extern crate libc;
 extern crate c_vec;
@@ -845,7 +843,7 @@ fn required_size(w: usize, h: usize, colortype: ColorType, bitdepth: u32) -> usi
 
 unsafe fn cvec_with_free<T>(ptr: *mut T, elts: usize) -> CVec<T>
     where T: Send {
-    CVec::new_with_dtor(::std::ptr::Unique::new(ptr), elts, |base: *mut T| {
+    CVec::new_with_dtor(ptr, elts, |base: *mut T| {
         free(base as *mut c_void);
     })
 }


### PR DESCRIPTION
This patch uses a later version of c_vec and the libc from crates.io so that the crate compiles on current stable and beta. The tests pass but I haven't tried using the library yet.