### PR TITLE
pin exact dep on c_vec 1.0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.1.8"
-c_vec = "1.0.12"
+c_vec = "= 1.0.12"
 
 [[example]]
 name = "read"


### PR DESCRIPTION
I know I already sent you a PR for stabilization, but I didn't realize how stubborn Cargo is with downloading "newer" versions from crates.io. This last change is required to keep cargo from "upgrading" to c_vec 1.1.0 which only works on nightly. I reported this at c_vec but it seems it's intended.