### PR TITLE
Fix mis-match in lodepng_convert definition

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -376,7 +376,7 @@ extern "C" {
     pub fn lodepng_add_text(info: &mut Info, key: *const c_char, str: *const c_char) -> Error;
     pub fn lodepng_clear_itext(info: &mut Info);
     pub fn lodepng_add_itext(info: &mut Info, key: *const c_char, langtag: *const c_char, transkey: *const c_char, str: *const c_char) -> Error;
-    pub fn lodepng_convert(out: *mut u8, input: *const u8, mode_out: &mut ColorMode, mode_in: &ColorMode, w: c_uint, h: c_uint, fix_png: c_uint) -> Error;
+    pub fn lodepng_convert(out: *mut u8, input: *const u8, mode_out: &mut ColorMode, mode_in: &ColorMode, w: c_uint, h: c_uint) -> Error;
     pub fn lodepng_decoder_settings_init(settings: &mut DecoderSettings);
     pub fn lodepng_auto_choose_color(mode_out: &mut ColorMode, image: *const u8, w: c_uint, h: c_uint, mode_in: &ColorMode, auto_convert: AutoConvert) -> Error;
     pub fn lodepng_encoder_settings_init(settings: &mut EncoderSettings);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,11 +662,11 @@ pub fn encode24_file<PixelType: Copy, P: AsRef<Path>>(filepath: P, image: &[Pixe
 
 /// Converts from any color type to 24-bit or 32-bit (only)
 #[doc(hidden)]
-pub fn convert<PixelType: Copy>(input: &[PixelType], mode_out: &mut ColorMode, mode_in: &ColorMode, w: usize, h: usize, fix_png: bool) -> Result<Image, Error> {
+pub fn convert<PixelType: Copy>(input: &[PixelType], mode_out: &mut ColorMode, mode_in: &ColorMode, w: usize, h: usize) -> Result<Image, Error> {
     unsafe {
         let out = mem::zeroed();
         try!(with_buffer_for_type(input, w, h, mode_in.colortype(), mode_in.bitdepth(), |ptr| {
-            ffi::lodepng_convert(out, ptr, mode_out, mode_in, w as c_uint, h as c_uint, fix_png as c_uint)
+            ffi::lodepng_convert(out, ptr, mode_out, mode_in, w as c_uint, h as c_uint)
         }).into());
         Ok(new_bitmap(out, w, h, mode_out.colortype(), mode_out.bitdepth()))
     }


### PR DESCRIPTION
The `lodepng_convert` in `vendor/lodepng.c:3459` doesn't have this argument, causing possible bugs.