### PR TITLE
Fix typo in README.md header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#[LodePNG](http://lodev.org/lodepng) bindings for [Rust](https://www.rust-lang.org)
+# [LodePNG](http://lodev.org/lodepng) bindings for [Rust](https://www.rust-lang.org)
 
 LodePNG is a stand-alone PNG image decoder and encoder (does *not* require zlib nor libpng).
 


### PR DESCRIPTION
Just add a space between the `#` and the text to make GitHub markdown format it correctly